### PR TITLE
import Javalin as another ws-server

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -50,6 +50,8 @@ slf4jVersion=1.7.32
 targetJvm=11
 jacocoVersion=0.8.7
 symZipVersion=0.10.1
+javalinVersion=5.0.1
+jacksonVersion=2.13.3
 # disable Kotlin MPP alpha warning:
 kotlin.mpp.stability.nowarn=true
 

--- a/projector-server-core/build.gradle.kts
+++ b/projector-server-core/build.gradle.kts
@@ -54,6 +54,8 @@ val kotlinVersion: String by project
 val ktorVersion: String by project
 val selenideVersion: String by project
 val slf4jVersion: String by project
+val javalinVersion: String by project
+val jacksonVersion: String by project
 
 val devBuilding = rootProject.file("local.properties").let {
   when (it.canRead()) {
@@ -138,6 +140,8 @@ dependencies {
   implementation("org.slf4j:slf4j-simple:$slf4jVersion")
   implementation("dnsjava:dnsjava:$dnsjavaVersion")
   implementation("org.jsoup:jsoup:$jsoupVersion")
+  implementation("io.javalin:javalin:$javalinVersion")
+  implementation("com.fasterxml.jackson.core:jackson-databind:$jacksonVersion")
 
   fun ModuleDependency.setupMarkdownDependency() {
     // These dependencies cannot be resolved as I cannot find the repository they are located in

--- a/projector-server-core/src/main/kotlin/org/jetbrains/projector/server/core/ClientSettings.kt
+++ b/projector-server-core/src/main/kotlin/org/jetbrains/projector/server/core/ClientSettings.kt
@@ -35,6 +35,8 @@ import org.jetbrains.projector.server.core.util.SizeAware
 import org.jetbrains.projector.util.logging.Logger
 import java.util.concurrent.ConcurrentLinkedQueue
 
+public const val CLIENT_SETTING: String = "CLIENT_SETTING"
+
 public sealed class ClientSettings {
 
   public abstract val connectionMillis: Long

--- a/projector-server-core/src/main/kotlin/org/jetbrains/projector/server/core/jwebsocket/JHttpWsServer.kt
+++ b/projector-server-core/src/main/kotlin/org/jetbrains/projector/server/core/jwebsocket/JHttpWsServer.kt
@@ -1,0 +1,115 @@
+package org.jetbrains.projector.server.core.jwebsocket
+
+import io.javalin.Javalin
+import io.javalin.http.staticfiles.Location
+import io.javalin.websocket.WsContext
+import org.jetbrains.projector.common.protocol.toClient.MainWindow
+import org.jetbrains.projector.server.core.ClientWrapper
+import org.jetbrains.projector.server.core.util.getWildcardHostAddress
+import org.jetbrains.projector.util.logging.Logger
+import java.io.InputStream
+import java.net.InetAddress
+import java.util.concurrent.ConcurrentHashMap
+
+public abstract class JHttpWsServer(host: InetAddress, port: Int) : JHttpWsTransport {
+
+  public constructor(port: Int) : this(getWildcardHostAddress(), port)
+
+  private val host: InetAddress = host
+  private val port: Int = port
+
+  private val connectMap = ConcurrentHashMap<WsContext, String>()
+
+  public abstract fun getMainWindows(): List<MainWindow>
+
+  private companion object {
+    private val logger = Logger<JHttpWsServer>()
+  }
+
+  @Volatile
+  private var wasInitialized = false
+
+  private val wStarted: Boolean
+    get() {
+     return wasInitialized
+    }
+
+  private val wsServer = Javalin.create{
+    it.staticFiles.add("/projector-client-web-distribution", Location.CLASSPATH)
+  }.ws("/") {
+    it.onConnect {
+      ctx -> onOpen(ctx)
+    }
+    it.onMessage {
+      ctx -> this@JHttpWsServer.onWsMessage(ctx, ctx.message())
+    }
+    it.onBinaryMessage {
+      ctx -> this@JHttpWsServer.onWsMessage(ctx, ctx.data())
+    }
+    it.onClose {
+      ctx -> this@JHttpWsServer.onWsClose(ctx)
+    }
+    it.onError {
+      ctx -> this@JHttpWsServer.onError(ctx, ctx.error())
+    }
+  }.get("/mainWindows") {
+    // endpoint of some static file that needs to handle path
+    it.json(getMainWindows())
+  }.get("/projector-client/{resourceFileName}") {
+
+    val rfn = it.pathParam("resourceFileName")
+    if (rfn.endsWith(".js")) {
+      it.res().setHeader("Content-Type", "text/javascript")
+    }
+
+    it.result(getResource(it.pathParam("resourceFileName")))
+  }.get("/projector/{resourceFileName}") {
+    it.result(getResource(it.pathParam("resourceFileName")))
+  }
+
+  private fun onOpen(ctx: WsContext) {
+    this.connectMap[ctx] = ""
+
+    ctx.session.maxTextMessageSize = Long.MAX_VALUE
+    ctx.session.maxBinaryMessageSize = Long.MAX_VALUE
+    return this@JHttpWsServer.onWsOpen(ctx)
+  }
+
+  private fun getResource(resourceFileName: String): InputStream {
+    try {
+      return this::class.java.getResource("/projector-client-web-distribution/$resourceFileName")?.openStream()!!
+    } catch (e: Exception) {
+      logger.error(e) { "Wrong file $resourceFileName" }
+    }
+    return this::class.java.getResource("/projector-client-web-distribution/$resourceFileName")?.openStream()!!
+  }
+
+  override val wasStarted: Boolean by JHttpWsServer::wStarted
+
+  override fun start() {
+    wsServer.start(this@JHttpWsServer.host.hostAddress, this@JHttpWsServer.port)
+
+    logger.info { "Server started on host $host and port $port" }
+    this.wasInitialized = true
+  }
+
+  override fun stop(timeoutMs: Int) {
+    wsServer.close()
+  }
+
+  override fun forEachOpenedConnection(action: (client: ClientWrapper) -> Unit) {
+    connectMap.keys.filter { it.session.isOpen }.forEach{
+      wsContext ->
+      run {
+        val sessionClientWrapper = wsContext.attribute<ClientWrapper>(CLIENT_WRAPPER)
+        if (sessionClientWrapper != null) {
+          try {
+            action(sessionClientWrapper)
+          } catch (e: Exception) {
+            logger.error(e) { "ERROR: sessionClientWrapper is $sessionClientWrapper , wsContext is $wsContext" }
+          }
+        }
+      }
+    }
+  }
+}

--- a/projector-server-core/src/main/kotlin/org/jetbrains/projector/server/core/jwebsocket/JHttpWsServerBuilder.kt
+++ b/projector-server-core/src/main/kotlin/org/jetbrains/projector/server/core/jwebsocket/JHttpWsServerBuilder.kt
@@ -1,0 +1,23 @@
+package org.jetbrains.projector.server.core.jwebsocket
+
+import io.javalin.websocket.WsContext
+import org.jetbrains.projector.common.protocol.toClient.MainWindow
+import java.net.InetAddress
+
+public class JHttpWsServerBuilder(private val host: InetAddress, private val port: Int): JWsTransportBuilder() {
+
+  public lateinit var getMainWindows: () -> List<MainWindow>
+
+  override fun build(): JHttpWsServer {
+
+    return object : JHttpWsServer(host, port) {
+      override fun getMainWindows(): List<MainWindow> = this@JHttpWsServerBuilder.getMainWindows()
+      override fun onError(wsContext: WsContext?, e: Throwable?) = this@JHttpWsServerBuilder.onError(wsContext, e)
+      override fun onWsOpen(wsContext: WsContext) = this@JHttpWsServerBuilder.onWsOpen(wsContext)
+      override fun onWsClose(wsContext: WsContext) = this@JHttpWsServerBuilder.onWsClose(wsContext)
+      override fun onWsMessage(wsContext: WsContext, message: String) = this@JHttpWsServerBuilder.onWsMessageString(wsContext, message)
+      override fun onWsMessage(wsContext: WsContext, message: ByteArray) = this@JHttpWsServerBuilder.onWsMessageByteBuffer(wsContext,
+                                                                                                                           message)
+    }
+  }
+}

--- a/projector-server-core/src/main/kotlin/org/jetbrains/projector/server/core/jwebsocket/JHttpWsTransport.kt
+++ b/projector-server-core/src/main/kotlin/org/jetbrains/projector/server/core/jwebsocket/JHttpWsTransport.kt
@@ -1,0 +1,19 @@
+package org.jetbrains.projector.server.core.jwebsocket
+
+import io.javalin.websocket.WsContext
+import org.jetbrains.projector.server.core.ServerTransport
+
+public interface JHttpWsTransport : ServerTransport {
+  override val clientCount: Int
+    get() {
+      var count = 0
+      forEachOpenedConnection { count++ }
+      return count
+    }
+
+  public fun onError(wsContext: WsContext?, e: Throwable?)
+  public fun onWsOpen(wsContext: WsContext)
+  public fun onWsClose(wsContext: WsContext)
+  public fun onWsMessage(wsContext: WsContext, message: String)
+  public fun onWsMessage(wsContext: WsContext, message: ByteArray)
+}

--- a/projector-server-core/src/main/kotlin/org/jetbrains/projector/server/core/jwebsocket/JWsClientWrapper.kt
+++ b/projector-server-core/src/main/kotlin/org/jetbrains/projector/server/core/jwebsocket/JWsClientWrapper.kt
@@ -1,0 +1,68 @@
+package org.jetbrains.projector.server.core.jwebsocket
+
+import io.javalin.websocket.WsContext
+import org.jetbrains.projector.server.core.CLIENT_SETTING
+import org.jetbrains.projector.server.core.ClientSettings
+import org.jetbrains.projector.server.core.ClientWrapper
+import org.jetbrains.projector.server.core.ClosedClientSettings
+import org.jetbrains.projector.util.logging.Logger
+import java.net.InetAddress
+import java.net.InetSocketAddress
+import java.nio.ByteBuffer
+
+public const val CLIENT_WRAPPER: String = "CLIENT_WRAPPER"
+
+public class JWsClientWrapper(private val wsContext: WsContext, initialSettings: ClientSettings): ClientWrapper {
+  override var settings: ClientSettings = initialSettings
+
+  override fun disconnect(reason: String) {
+    val conn = wsContext
+    conn.closeSession()
+
+    val clientSettings = conn.attribute<ClientSettings>(CLIENT_SETTING)!!
+    logger.info { "Disconnecting user ${clientSettings.address}. Reason: $reason" }
+    conn.attribute(
+      CLIENT_SETTING,
+      ClosedClientSettings(
+        connectionMillis = clientSettings.connectionMillis,
+        address = clientSettings.address,
+        reason = reason,
+      )
+    )
+  }
+
+  override fun send(data: ByteArray) {
+    try {
+      // Javalin ws send ByteArray will use send(Any), it may lead to fault, so using send(ByteBuffer)
+      wsContext.send(ByteBuffer.wrap(data))
+    }
+    catch (e: Exception) {
+      logger.debug(e) { "While generating message, client disconnected" }
+    }
+  }
+
+  override val requiresConfirmation: Boolean
+    get() {
+      val remoteAddress = wsContext.session.remoteAddress
+      if (remoteAddress is InetSocketAddress) {
+        return remoteAddress.address?.isLoopbackAddress != true
+      }
+      return false
+    }
+
+  override val confirmationRemoteIp: InetAddress?
+    get() {
+      val remoteAddress = wsContext.session.remoteAddress
+      if (remoteAddress is InetSocketAddress) {
+        return remoteAddress.address
+      }
+      return null
+    }
+
+  override val confirmationRemoteName: String
+    get() = "unknown host"
+
+  private companion object {
+    private val logger = Logger<JWsClientWrapper>()
+  }
+}

--- a/projector-server-core/src/main/kotlin/org/jetbrains/projector/server/core/jwebsocket/JWsTransportBuilder.kt
+++ b/projector-server-core/src/main/kotlin/org/jetbrains/projector/server/core/jwebsocket/JWsTransportBuilder.kt
@@ -1,0 +1,70 @@
+package org.jetbrains.projector.server.core.jwebsocket
+
+import io.javalin.websocket.WsContext
+import org.jetbrains.projector.server.core.ClientEventHandler
+import org.jetbrains.projector.server.core.ClientWrapper
+import org.jetbrains.projector.util.logging.Logger
+import java.net.InetSocketAddress
+
+public abstract class JWsTransportBuilder {
+  public lateinit var onError: (WsContext?, Throwable?) -> Unit
+  public lateinit var onWsOpen: (wsContext: WsContext) -> Unit
+  public lateinit var onWsClose: (wsContext: WsContext) -> Unit
+  public lateinit var onWsMessageString: (wsContext: WsContext, message: String) -> Unit
+  public lateinit var onWsMessageByteBuffer: (wsContext: WsContext, message: ByteArray) -> Unit
+
+  public abstract fun build(): JHttpWsTransport
+
+  public fun attachDefaultServerEventHandlers(clientEventHandler: ClientEventHandler): JWsTransportBuilder {
+    onWsMessageByteBuffer = { _, message ->
+      throw RuntimeException("Unsupported message type: $message")
+    }
+
+    onWsMessageString = { wsContext, message ->
+      clientEventHandler.handleMessage(wsContext.attribute<ClientWrapper>(CLIENT_WRAPPER)!!, message)
+    }
+
+    onWsClose = { wsContext ->
+      // todo: we need more informative message, add parameters to this method inside the superclass
+      clientEventHandler.updateClientsCount()
+      val wrapper = wsContext.attribute<ClientWrapper>(CLIENT_WRAPPER)
+      if (wrapper != null) {
+        clientEventHandler.onClientConnectionEnded(wrapper)
+      } else {
+        logger.info {
+          val address = wsHostAddress(wsContext)
+          "Client from address $address is disconnected. This client hasn't clientSettings. " +
+          "This usually happens when the handshake stage didn't have time to be performed " +
+          "(so it seems the client has been connected for a very short time)"
+        }
+      }
+    }
+
+    onWsOpen = { wsContext ->
+      val address = wsHostAddress(wsContext)
+      val wrapper = JWsClientWrapper(wsContext, clientEventHandler.getInitialClientState(address))
+      wsContext.attribute(CLIENT_WRAPPER, wrapper)
+      logger.info { "$address connected." }
+      clientEventHandler.onClientConnected(wrapper)
+    }
+
+    onError = { _, e ->
+      logger.error(e) { "onError" }
+    }
+
+    return this
+  }
+
+  private fun wsHostAddress(wsContext: WsContext): String? {
+    val remoteAddress = wsContext.session.remoteAddress
+    var address: String? = "UNKNOWN"
+    if (remoteAddress is InetSocketAddress) {
+      address = remoteAddress.address?.hostAddress
+    }
+    return address
+  }
+
+  private companion object {
+    private val logger = Logger<JWsTransportBuilder>()
+  }
+}


### PR DESCRIPTION
You can use -DORG_JETBRAINS_PROJECTOR_SERVER_ENABLE_JETTY_WS=true at Projector startup args to enable Javalin as websocket server  

Server PR: https://github.com/zhipengzuo/projector-server/pull/1